### PR TITLE
Saving User Options to NetCDF Attributes

### DIFF
--- a/Examples/Filament/do_roms.sh
+++ b/Examples/Filament/do_roms.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 #mpiexec -np 6 roms river_ana.in < /dev/null > & jobout &
-mpiexec -np 6 roms river_ana.in 
+mpiexec -np 6 ./roms filament.in 

--- a/Examples/Filament/do_roms.sh
+++ b/Examples/Filament/do_roms.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 
-mpiexec -np 6 roms river_ana.in < /dev/null > & jobout &
+#mpiexec -np 6 roms river_ana.in < /dev/null > & jobout &
+mpiexec -np 6 roms river_ana.in 

--- a/Examples/Filament/join.sh
+++ b/Examples/Filament/join.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 
-rm grid.*
-ncjoin --delete ideal_his*.?.nc
-ncview ideal_his.*.nc &
+#rm grid.*
+#ncjoin --delete ideal_his*.?.nc
+#ncview ideal_his.*.nc &
+
+ncjoin --delete fila_his*.?.nc 
+ncview fila_his.*.nc 
 

--- a/Examples/Makefile
+++ b/Examples/Makefile
@@ -13,7 +13,7 @@
 
 .PHONY: all clean depend
 
-ROMS_ROOT = /home/nmolem/ucla-roms
+#ROMS_ROOT = /home/nmolem/ucla-roms
 
 all:
 	@echo "Doing my thing"

--- a/Examples/Makefile
+++ b/Examples/Makefile
@@ -13,7 +13,8 @@
 
 .PHONY: all clean depend
 
-#ROMS_ROOT = /home/nmolem/ucla-roms
+
+
 
 all:
 	@echo "Doing my thing"

--- a/Examples/Rivers_real/do_roms.sh
+++ b/Examples/Rivers_real/do_roms.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
 echo "run model..."
-mpirun -n 6 ./roms rivers.in
+mpiexec -n 6 ./roms rivers.in
 echo "complete!"

--- a/Examples/Tides/tides.opt
+++ b/Examples/Tides/tides.opt
@@ -5,6 +5,7 @@
       integer, parameter, public :: ntides=15 ! Number of tidal components to consider.
       logical, parameter, public :: bry_tides = .true.
       logical, parameter, public :: pot_tides = .true.
+      logical, parameter, public :: ana_tides = .true.
 
       ! end user inputs
       ! ****************************************************************

--- a/src/Makedefs.inc
+++ b/src/Makedefs.inc
@@ -33,7 +33,6 @@
     CPP = cpp -traditional
 
 # Path names (non-hydrostatic & NetCDF libraries):
-	ROMS_ROOT = /home/nmolem/ucla-roms/
 
 	NHMG_ROOT = $(ROMS_ROOT)/NHMG
 	NHMG_LIB  = -L$(NHMG_ROOT)/lib -lnhmg

--- a/src/boundary.F
+++ b/src/boundary.F
@@ -77,7 +77,9 @@
 
       ! local
       integer :: itrc
-
+      if (obc_west.or.obc_east.or.obc_north.or.obc_south) then
+        bc_options = ''
+      endif 
       if (obc_west)  call store_string_att(bc_options,'OBC_WEST, ')
       if (obc_east)  call store_string_att(bc_options,'OBC_EAST, ')
       if (obc_north) call store_string_att(bc_options,'OBC_NORTH, ')

--- a/src/bulk_frc.F
+++ b/src/bulk_frc.F
@@ -69,6 +69,14 @@
         nc_swrad%coarse = 1
       endif
 
+      ! Print option to netcdf file 
+      bulk_frc_opt = ''
+      call store_string_att(bulk_frc_opt, 'True')
+      if (interp_frc==1) then 
+        call store_string_att(bulk_frc_opt, 'Interpolation = True')
+      else 
+        call store_string_att(bulk_frc_opt, 'Interpolation = False') 
+      endif 
 
       end subroutine init_arrays_bulk_frc  !]
 ! ----------------------------------------------------------------------

--- a/src/bulk_frc.F
+++ b/src/bulk_frc.F
@@ -69,14 +69,12 @@
         nc_swrad%coarse = 1
       endif
 
-      ! Print option to netcdf file 
+      ! Print user options (bulk_frc.opt) to netcdf attributes 
+      ! Note: to turn bulk forces off, edit cppdefs! 
       bulk_frc_opt = ''
       call store_string_att(bulk_frc_opt, 'True')
-      if (interp_frc==1) then 
-        call store_string_att(bulk_frc_opt, 'Interpolation = True')
-      else 
-        call store_string_att(bulk_frc_opt, 'Interpolation = False') 
-      endif 
+      if (interp_frc==1) call store_string_att(bulk_frc_opt,
+     &                                         ', Interpolated')
 
       end subroutine init_arrays_bulk_frc  !]
 ! ----------------------------------------------------------------------

--- a/src/diagnostics.F
+++ b/src/diagnostics.F
@@ -278,17 +278,12 @@
       if (mynode==0) print *,'init diagnostics', init_done
       init_done = .true.  ! ensure init is not triggered again
 
-      ! Print diagnostics opts to netcdf 
+      ! Print diagnostics opts (diagnostics.opt) to netcdf attributes
       call store_string_att(diagnostic_opt, 'Chosen Diagnostics = ')
-      if (diag_uv) then 
-        call store_string_att(diagnostic_opt, 'Momentum')
-      endif
-      if (diag_trc) then 
-        call store_string_att(diagnostic_opt, '/ Selected Tracers')
-      endif
-      if (diag_pflx) then 
-        call store_string_att(diagnostic_opt, '/ Baroclinic Pressure Fluxes')
-      endif
+      if (diag_uv) call store_string_att(diagnostic_opt, 'Momentum')
+      if (diag_trc) call store_string_att(diagnostic_opt, ', Selected Tracers')
+      if (diag_pflx) call store_string_att(diagnostic_opt, 
+     &                                     ', Baroclinic Pressure Fluxes')
 
       end subroutine init_diagnostics  !]
 ! ----------------------------------------------------------------------

--- a/src/diagnostics.F
+++ b/src/diagnostics.F
@@ -278,6 +278,18 @@
       if (mynode==0) print *,'init diagnostics', init_done
       init_done = .true.  ! ensure init is not triggered again
 
+      ! Print diagnostics opts to netcdf 
+      call store_string_att(diagnostic_opt, 'Chosen Diagnostics = ')
+      if (diag_uv) then 
+        call store_string_att(diagnostic_opt, 'Momentum')
+      endif
+      if (diag_trc) then 
+        call store_string_att(diagnostic_opt, '/ Selected Tracers')
+      endif
+      if (diag_pflx) then 
+        call store_string_att(diagnostic_opt, '/ Baroclinic Pressure Fluxes')
+      endif
+
       end subroutine init_diagnostics  !]
 ! ----------------------------------------------------------------------
       subroutine set_diags_u_4th_adv  ![

--- a/src/flux_frc.F
+++ b/src/flux_frc.F
@@ -48,14 +48,12 @@
         nc_swrad%coarse=1
       endif
 
-      ! Print option to netcdf file 
+      ! Print user options (flux_frc.opt) to netcdf attributes
+      ! Note: to turn flux forces off, edit cppdefs! 
       flux_frc_opt = ''
       call store_string_att(flux_frc_opt, 'True')
-      if (interp_frc==1) then
-        call store_string_att(flux_frc_opt, '/ Interpolation = True')
-      else
-        call store_string_att(flux_frc_opt, '/ Interpolation = False') 
-      endif 
+      if (interp_frc==1) call store_string_att(flux_frc_opt, 
+     &                                         ', Interpolated')
 
       end subroutine init_arrays_flux_frc  !]
 ! ----------------------------------------------------------------------

--- a/src/flux_frc.F
+++ b/src/flux_frc.F
@@ -48,6 +48,15 @@
         nc_swrad%coarse=1
       endif
 
+      ! Print option to netcdf file 
+      flux_frc_opt = ''
+      call store_string_att(flux_frc_opt, 'True')
+      if (interp_frc==1) then
+        call store_string_att(flux_frc_opt, '/ Interpolation = True')
+      else
+        call store_string_att(flux_frc_opt, '/ Interpolation = False') 
+      endif 
+
       end subroutine init_arrays_flux_frc  !]
 ! ----------------------------------------------------------------------
       subroutine set_flux_frc(istr,iend,jstr,jend)  ![

--- a/src/main.F
+++ b/src/main.F
@@ -209,6 +209,7 @@ CR      write(*,*) ' -6' MYID
       call ecosys2_init
 # endif /*BIOLOGY_BEC2*/
 
+      
 #ifdef ANA_INITIAL
                                     ! Set initial conditions for
       call set_forces               ! model prognostic variables,
@@ -216,6 +217,7 @@ CR      write(*,*) ' -6' MYID
                                     ! either analytically or read
       if (nrrec > 0) then 
 #endif
+      
 #ifdef EXACT_RESTART
         call get_init(nrrec-1,2) 
         call set_depth(0)
@@ -231,10 +233,9 @@ CR      write(*,*) ' -6' MYID
       time=start_time             ! moment "start_time" (global scalar)
       tdays=time*sec2day          ! is set by get_init or analytically
                                   ! copy it into threadprivate "time"
-
+      call set_forces
       call set_depth(0)
 C$OMP BARRIER
-
 !----------------------------------------------------------------------
 !  Set NHMG horizontal and vertical grids 
 !  then set matrices coefficients for the elliptic problem

--- a/src/particles.F
+++ b/src/particles.F
@@ -177,18 +177,18 @@
       call wrt_particles
       output_time = 0
 
-      ! Print options to netcdf 
+      ! Print user options (particles.opt) to netcdf attributes 
       call store_string_att(particle_opt, '')
       if (full_seed) then 
         call store_string_att(particle_opt, 'Seeded with constant density')
-        write(particle_conc_string, '(A, E10.2)') '/ Partcile Conc. =', ppm3
+        write(particle_conc_string, '(A, E10.2)') ', Partcile Conc. =', ppm3
         call store_string_att(particle_opt, particle_conc_string)
-        write(particle_num_string, '(A, I2)') '/ Number of Partciles =', np
+        write(particle_num_string, '(A, I2)') ', Number of Partciles =', np
         call store_string_att(particle_opt, particle_num_string)
       else 
         call store_string_att(particle_opt, 'Seeded Randomly')
       endif
-      write(buffer_string, '(A, F5.3)') '/ Buffer Space =', extra_space_fac
+      write(buffer_string, '(A, F5.3)') ', Buffer Space =', extra_space_fac
       call store_string_att(particle_opt, buffer_string)
        
 

--- a/src/particles.F
+++ b/src/particles.F
@@ -27,6 +27,10 @@
       ! particles would be slower than going through an array that is
       ! stored in contiguous memory.
       
+      character(len=30) :: particle_num_string  
+      character(len=30) :: particle_conc_string  
+      character(len=30) :: buffer_string  
+
       ! indices of various quantities in particle array
       integer,parameter :: itag = 1   ! identification tag
       integer,parameter :: ipx  = 2   ! x-position (index space)
@@ -173,6 +177,20 @@
       call wrt_particles
       output_time = 0
 
+      ! Print options to netcdf 
+      call store_string_att(particle_opt, '')
+      if (full_seed) then 
+        call store_string_att(particle_opt, 'Seeded with constant density')
+        write(particle_conc_string, '(A, E10.2)') '/ Partcile Conc. =', ppm3
+        call store_string_att(particle_opt, particle_conc_string)
+        write(particle_num_string, '(A, I2)') '/ Number of Partciles =', np
+        call store_string_att(particle_opt, particle_num_string)
+      else 
+        call store_string_att(particle_opt, 'Seeded Randomly')
+      endif
+      write(buffer_string, '(A, F5.3)') '/ Buffer Space =', extra_space_fac
+      call store_string_att(particle_opt, buffer_string)
+       
 
 !     print *,'init particles done'
 

--- a/src/pipe_frc.F
+++ b/src/pipe_frc.F
@@ -41,6 +41,10 @@
       character(len=5)  ::npipe_dim_name = 'npipe'      !! dimension name for number of pipes in file
       character(len=8)  :: ntrc_dim_name = 'ntracers'   !! dimension name for number of tracers in file
 
+     ! Netcdf Prints for ncinfo 
+      character(len=30) :: string  
+       
+
       logical :: init_pipe_done = .false.
 
       public set_pipe_frc
@@ -143,6 +147,18 @@
         allocate(nc_pvol%vdata(npip,1 ,2))
         allocate(nc_ptrc%vdata(npip,nt,2))
       endif
+
+      ! Print statements 
+      pipe_frc_opt = ''
+      if (pipe_source) then 
+        write(string, '(A,I3)') 'npip =', npip
+        call store_string_att(pipe_frc_opt, string)
+        if (p_analytical) then
+          call store_string_att(pipe_frc_opt, '/ Analytical')
+        else
+          call store_string_att(pipe_frc_opt, '/ Realistic')
+        endif
+      endif 
 
       end subroutine init_arrays_pipes  !]
 ! ----------------------------------------------------------------------

--- a/src/pipe_frc.F
+++ b/src/pipe_frc.F
@@ -41,9 +41,6 @@
       character(len=5)  ::npipe_dim_name = 'npipe'      !! dimension name for number of pipes in file
       character(len=8)  :: ntrc_dim_name = 'ntracers'   !! dimension name for number of tracers in file
 
-     ! Netcdf Prints for ncinfo 
-      character(len=30) :: string  
-       
 
       logical :: init_pipe_done = .false.
 
@@ -138,6 +135,7 @@
       subroutine init_arrays_pipes  ![
       implicit none
 
+      character(len=30) :: string  
       allocate( pipe_idx(GLOBAL_2D_ARRAY) );      pipe_idx=0.
       allocate( pipe_fraction(GLOBAL_2D_ARRAY) ); pipe_fraction=0.
       allocate( pipe_flx(GLOBAL_2D_ARRAY) );      pipe_flx=0.

--- a/src/pipe_frc.F
+++ b/src/pipe_frc.F
@@ -107,7 +107,7 @@
 
       if (p_analytical) then
 
-        ! pipe_flx is defined in ana_grid()
+        ! pipe_flx is defined in ana_pipe_frc.h
 
       else
 
@@ -148,17 +148,13 @@
         allocate(nc_ptrc%vdata(npip,nt,2))
       endif
 
-      ! Print statements 
+      ! Print user options (pipe_frc.opt) to netcdf attributes 
       pipe_frc_opt = ''
-      if (pipe_source) then 
-        write(string, '(A,I3)') 'npip =', npip
-        call store_string_att(pipe_frc_opt, string)
-        if (p_analytical) then
-          call store_string_att(pipe_frc_opt, '/ Analytical')
-        else
-          call store_string_att(pipe_frc_opt, '/ Realistic')
-        endif
-      endif 
+      write(string, '(A,I3)') 'npip =', npip
+      call store_string_att(pipe_frc_opt, string)
+      if (p_analytical) then
+        call store_string_att(pipe_frc_opt, ', Analytical')
+      endif
 
       end subroutine init_arrays_pipes  !]
 ! ----------------------------------------------------------------------

--- a/src/river_frc.F
+++ b/src/river_frc.F
@@ -41,9 +41,6 @@
       character(len=6) :: nriv_dim_name = 'nriver'                   ! dimension name for number of rivers in file
       character(len=8) :: ntrc_dim_name = 'ntracers'                 ! dimension name for number of tracers in file
       
-      ! Option values printed to netcdf
-      character(len=30) :: string                 
-      
       ! Misc:
       logical, public :: init_riv_done = .false.                     ! if river variables have been initialized yet
 
@@ -93,6 +90,7 @@
       integer :: ierr,ncid,varid
       real  :: riv_cells,riv_east,riv_west
 
+      character(len=30) :: string                 
       allocate( riv_uflx(GLOBAL_2D_ARRAY) ); riv_uflx = 0.
       allocate( riv_vflx(GLOBAL_2D_ARRAY) ); riv_vflx = 0.
       allocate( rflx(GLOBAL_2D_ARRAY) )    ; rflx = 0.
@@ -146,7 +144,7 @@
 
       ! Print user options (river_frc.opt) to netcdf attributes
       river_frc_opt = ''
-      write(string, '(A,I2)') 'nriv =', nriv
+      write(string, '(A,I3)') 'nriv =', nriv
       call store_string_att(river_frc_opt, string)
       if (analytical) then 
         call store_string_att(river_frc_opt, ', Analytical')

--- a/src/river_frc.F
+++ b/src/river_frc.F
@@ -40,7 +40,10 @@
       character(len=10) :: riv_tim_name = 'river_time'               ! stored in a forcing file
       character(len=6) :: nriv_dim_name = 'nriver'                   ! dimension name for number of rivers in file
       character(len=8) :: ntrc_dim_name = 'ntracers'                 ! dimension name for number of tracers in file
-
+      
+      ! Option values printed to netcdf
+      character(len=30) :: string                 
+      
       ! Misc:
       logical, public :: init_riv_done = .false.                     ! if river variables have been initialized yet
 
@@ -139,6 +142,19 @@
 
       if(mynode==0) write(*,'(/7x,A/)')
      &  'river_frc: init river locations'
+
+      ! Print statements for netcdf  
+      river_frc_opt = ''
+      if (river_source) then
+        write(string, '(A,I3)') 'nriv =', nriv
+        call store_string_att(river_frc_opt, string)
+        if (analytical) then
+          call store_string_att(river_frc_opt, '/ Analytical')
+        else
+          call store_string_att(river_frc_opt, '/ Realistic')
+        endif
+      endif
+
 
       end subroutine init_river_frc  !]
 ! ----------------------------------------------------------------------

--- a/src/river_frc.F
+++ b/src/river_frc.F
@@ -77,6 +77,7 @@
 
       endif
 
+
       end subroutine set_river_frc  !]
 ! ----------------------------------------------------------------------
       subroutine init_river_frc  ![
@@ -87,7 +88,6 @@
       ! subroutine
       use netcdf
       implicit none
-
       ! local
       integer :: i,j
       integer :: ierr,ncid,varid
@@ -134,6 +134,7 @@
         ierr=nf90_open(grdname, nf90_nowrite, ncid)
         call ncread(ncid, riv_flx_name, rflx(i0:i1,j0:j1) )
         if(ierr/=0) call handle_ierr(ierr,'init_riv:: riv not in file!')
+        
       endif
 
       call calc_river_flux                                           ! compute uflx,vflx from rflx
@@ -143,19 +144,16 @@
       if(mynode==0) write(*,'(/7x,A/)')
      &  'river_frc: init river locations'
 
-      ! Print statements for netcdf  
+      ! Print user options (river_frc.opt) to netcdf attributes
       river_frc_opt = ''
-      if (river_source) then
-        write(string, '(A,I3)') 'nriv =', nriv
-        call store_string_att(river_frc_opt, string)
-        if (analytical) then
-          call store_string_att(river_frc_opt, '/ Analytical')
-        else
-          call store_string_att(river_frc_opt, '/ Realistic')
-        endif
+      write(string, '(A,I2)') 'nriv =', nriv
+      call store_string_att(river_frc_opt, string)
+      if (analytical) then 
+        call store_string_att(river_frc_opt, ', Analytical')
       endif
-
-
+      print *, 'Done with attributes', mynode 
+      print "(a15)", river_frc_opt
+      print "(a15)", ierr
       end subroutine init_river_frc  !]
 ! ----------------------------------------------------------------------
       subroutine calc_river_flux  ![

--- a/src/roms_read_write.F
+++ b/src/roms_read_write.F
@@ -80,8 +80,16 @@
       real,dimension(:,:),allocatable   :: cdata     ! Array to read in coarse surface forcing data
 
       integer,parameter :: max_options_string=2000
-      character(len=max_options_string),public::surf_forcing_strings=' '
-      character(len=max_options_string),public::bc_options = ' '
+     ! character(len=max_options_string),public::surf_forcing_strings=' '
+      character(len=max_options_string),public::bc_options = 'False'
+      character(len=max_options_string),public::pipe_frc_opt='False'
+      character(len=max_options_string),public::river_frc_opt='False'
+      character(len=max_options_string),public::tide_opt='False'
+      character(len=max_options_string),public::bulk_frc_opt='False'
+      character(len=max_options_string),public::flux_frc_opt='False'
+      character(len=max_options_string),public::particle_opt='False'
+      character(len=max_options_string),public::diagnostic_opt='False'
+      
 
       ! from old ncvars **************:
       integer, parameter, public :: max_frc_files=360
@@ -1288,8 +1296,15 @@
       ! string set added to get values from modules without struggling with circular references
       ! as those modules use roms_read_write so this module can't use them.
       ! rather the string is filled in the module's init and can be written here to all files.
-      ierr=nf90_put_att (ncid, nf90_global, 'surf_forcing_strings', surf_forcing_strings)
+      !ierr=nf90_put_att (ncid, nf90_global, 'surf_forcing_strings', surf_forcing_strings)
       ierr=nf90_put_att (ncid, nf90_global, 'bc_options', bc_options)
+      ierr=nf90_put_att (ncid, nf90_global, 'bulk_frc_options', bulk_frc_opt)
+      ierr=nf90_put_att (ncid, nf90_global, 'flux_frc_options', flux_frc_opt)
+      ierr=nf90_put_att (ncid, nf90_global, 'tide_options', tide_opt)
+      ierr=nf90_put_att (ncid, nf90_global, 'river_frc_options', river_frc_opt)
+      ierr=nf90_put_att (ncid, nf90_global, 'pipe_frc_options', pipe_frc_opt)
+      ierr=nf90_put_att (ncid, nf90_global, 'particle_options', particle_opt)
+      ierr=nf90_put_att (ncid, nf90_global, 'diagnostic_options', diagnostic_opt)
 
       call add_git_hash(ncid)
 

--- a/src/roms_read_write.F
+++ b/src/roms_read_write.F
@@ -80,7 +80,6 @@
       real,dimension(:,:),allocatable   :: cdata     ! Array to read in coarse surface forcing data
 
       integer,parameter :: max_options_string=2000
-     ! character(len=max_options_string),public::surf_forcing_strings=' '
       character(len=max_options_string),public::bc_options = 'False'
       character(len=max_options_string),public::pipe_frc_opt='False'
       character(len=max_options_string),public::river_frc_opt='False'
@@ -804,10 +803,10 @@
         call append_date_node(fname)
       endif
 
-!     if (mynode==0) then
-!       print *,'creating: ',fname
-!       stop
-!     endif
+!      if (mynode==0) then
+!        print *,'creating: ',fname
+!        stop
+!      endif
 
       ierr=nf90_create(trim(fname),nf90_netcdf4,ncid)
       if (ierr/=nf90_noerr) 
@@ -1296,7 +1295,6 @@
       ! string set added to get values from modules without struggling with circular references
       ! as those modules use roms_read_write so this module can't use them.
       ! rather the string is filled in the module's init and can be written here to all files.
-      !ierr=nf90_put_att (ncid, nf90_global, 'surf_forcing_strings', surf_forcing_strings)
       ierr=nf90_put_att (ncid, nf90_global, 'bc_options', bc_options)
       ierr=nf90_put_att (ncid, nf90_global, 'bulk_frc_options', bulk_frc_opt)
       ierr=nf90_put_att (ncid, nf90_global, 'flux_frc_options', flux_frc_opt)
@@ -1305,7 +1303,6 @@
       ierr=nf90_put_att (ncid, nf90_global, 'pipe_frc_options', pipe_frc_opt)
       ierr=nf90_put_att (ncid, nf90_global, 'particle_options', particle_opt)
       ierr=nf90_put_att (ncid, nf90_global, 'diagnostic_options', diagnostic_opt)
-
       call add_git_hash(ncid)
 
       end subroutine put_global_atts  !]
@@ -1314,7 +1311,6 @@
       ! Add settings that affect the solution to a string
       ! which will be added to global attributes of all nc files
       implicit none
-
       ! input
       character(len=*),intent(inout) :: char_string
       character(len=*),intent(in)    :: string_add

--- a/src/surf_flux.F
+++ b/src/surf_flux.F
@@ -76,7 +76,6 @@
       implicit none
 
       ! local
-      character(len=30) :: string
       allocate(  uwnd  (GLOBAL_2D_ARRAY)    );
       allocate(  vwnd  (GLOBAL_2D_ARRAY)    );       
       allocate( sustr  (GLOBAL_2D_ARRAY)    ); sustr=init
@@ -90,12 +89,6 @@
       allocate( sss(GLOBAL_2D_ARRAY)        ); sss=init
       allocate(nc_sss%vdata(GLOBAL_2D_ARRAY,2) )
 
-     ! call store_string_att(surf_forcing_strings,'<surf_flux.F>')
-     ! call store_string_att(surf_forcing_strings,'dSSSdt=')
-     ! write (string, "(F9.6)") dSSSdt*(100.*day2sec)                 ! convert number to string...
-     ! call store_string_att(surf_forcing_strings,string)
-     ! call store_string_att(surf_forcing_strings,'dSSSdt_units')
-     ! call store_string_att(surf_forcing_strings,'cm/day')
 #endif
 
       if (sflx_avg) then

--- a/src/surf_flux.F
+++ b/src/surf_flux.F
@@ -90,12 +90,12 @@
       allocate( sss(GLOBAL_2D_ARRAY)        ); sss=init
       allocate(nc_sss%vdata(GLOBAL_2D_ARRAY,2) )
 
-      call store_string_att(surf_forcing_strings,'<surf_flux.F>')
-      call store_string_att(surf_forcing_strings,'dSSSdt=')
-      write (string, "(F9.6)") dSSSdt*(100.*day2sec)                 ! convert number to string...
-      call store_string_att(surf_forcing_strings,string)
-      call store_string_att(surf_forcing_strings,'dSSSdt_units')
-      call store_string_att(surf_forcing_strings,'cm/day')
+     ! call store_string_att(surf_forcing_strings,'<surf_flux.F>')
+     ! call store_string_att(surf_forcing_strings,'dSSSdt=')
+     ! write (string, "(F9.6)") dSSSdt*(100.*day2sec)                 ! convert number to string...
+     ! call store_string_att(surf_forcing_strings,string)
+     ! call store_string_att(surf_forcing_strings,'dSSSdt_units')
+     ! call store_string_att(surf_forcing_strings,'cm/day')
 #endif
 
       if (sflx_avg) then

--- a/src/tides.F
+++ b/src/tides.F
@@ -24,6 +24,9 @@
 
       public set_tides
 
+      ! printing to netcdf
+      character(len=30) :: string 
+
       contains
 
 !-----------------------------------------------------------------------
@@ -49,13 +52,28 @@
         allocate(ptide(GLOBAL_2D_ARRAY))
       endif
 
+      ! Save tide options to netcdf and call respective sub routines 
+      ! based on options 
+      tide_opt = ''
       if (pot_tides.or.bry_tides) then
+        write(string, '(A, I3)') 'ntides =', ntides
+        call store_string_att(tide_opt, string)
         if (ana_tides) then
           call make_tides
+          call store_string_att(tide_opt, '/ Analytical')
         else
           call read_tides
+          call store_string_att(tide_opt, '/ Realistic')
         endif
       endif
+
+      ! Save additional tide options to netcdf 
+      if (pot_tides) then 
+        call store_string_att(tide_opt, '/ Tidal Potential = True')
+      endif
+      if (bry_tides) then 
+        call store_string_att(tide_opt, '/ Barotropic Tides = True') 
+      endif 
 
       end subroutine init_tides  !]
 !-----------------------------------------------------------------------

--- a/src/tides.F
+++ b/src/tides.F
@@ -52,28 +52,22 @@
         allocate(ptide(GLOBAL_2D_ARRAY))
       endif
 
-      ! Save tide options to netcdf and call respective sub routines 
-      ! based on options 
-      tide_opt = ''
       if (pot_tides.or.bry_tides) then
-        write(string, '(A, I3)') 'ntides =', ntides
-        call store_string_att(tide_opt, string)
         if (ana_tides) then
           call make_tides
-          call store_string_att(tide_opt, '/ Analytical')
         else
           call read_tides
-          call store_string_att(tide_opt, '/ Realistic')
         endif
       endif
 
-      ! Save additional tide options to netcdf 
-      if (pot_tides) then 
-        call store_string_att(tide_opt, '/ Tidal Potential = True')
-      endif
-      if (bry_tides) then 
-        call store_string_att(tide_opt, '/ Barotropic Tides = True') 
-      endif 
+      ! Print user options (tides.opt) to netcdf attributes
+      tide_opt = ''
+      write(string, '(A, I3)') 'ntides =', ntides
+      call store_string_att(tide_opt, string)
+      if (ana_tides) call store_string_att(tide_opt, ', Analytical tides')
+      if (pot_tides) call store_string_att(tide_opt, ', Tidal potential')
+      if (bry_tides) call store_string_att(tide_opt, 
+     &                                     'Barotropic tide at boundary') 
 
       end subroutine init_tides  !]
 !-----------------------------------------------------------------------

--- a/src/tides.F
+++ b/src/tides.F
@@ -24,9 +24,6 @@
 
       public set_tides
 
-      ! printing to netcdf
-      character(len=30) :: string 
-
       contains
 
 !-----------------------------------------------------------------------
@@ -35,6 +32,7 @@
 
       implicit none
 
+      character(len=30) :: string 
       allocate(ftide(ntides))
 
       if (bry_tides) then
@@ -62,7 +60,7 @@
 
       ! Print user options (tides.opt) to netcdf attributes
       tide_opt = ''
-      write(string, '(A, I3)') 'ntides =', ntides
+      write(string, '(A, I2)') 'ntides =', ntides
       call store_string_att(tide_opt, string)
       if (ana_tides) call store_string_att(tide_opt, ', Analytical tides')
       if (pot_tides) call store_string_att(tide_opt, ', Tidal potential')


### PR DESCRIPTION
Users may edit modules in the source code through option files that range from the types of forcing to presence of pipes and rivers. To make replicating runs easier, these options are now saved as attributes to the netCDF history files outputted during the run. That is, viewing a netCDF via 'ncdump -h <filename.nc>', the user will see relevant options regarding tides, pipes, rivers, surface forcing, tracking diagnostics,  and the presence of particles. 