### PR TITLE
New branch working to streamline initialization

### DIFF
--- a/Examples/Pipes_ana/ana_grid.h
+++ b/Examples/Pipes_ana/ana_grid.h
@@ -11,7 +11,6 @@
       real dh, shelf, slope, land, coast
       real :: depth,max_depth
       real riv_west, riv_east,riv_cells
-      real psz,px,py,pipe_cells
 
       SizeX = 30.0e3  !! Domain size in x-direction [m]
       SizeY = 30.0e3  !! Domain size in y-direction [m]
@@ -94,21 +93,3 @@
         enddo
       enddo
 
-      if (pipe_source) then
-        psz = sizeX*0.02 ! Width of the pipe
-        px  = sizeX*.5  ! x location pipe 
-        py  = sizeY*.5  ! y location pipe 
-        pipe_cells = nint(psz/dx)**2 !number of cells in this pipe
-        do j=-1,ny+2
-          do i=-1,nx+2
-            pipe_fraction(i,j) = 0.0
-            pipe_idx(i,j) = 0
-            if (xr(i,j)> px-0.5*psz .and. xr(i,j)<px+0.5*psz) then
-              if (yr(i,j)> py-0.5*psz .and. yr(i,j)<py+0.5*psz) then
-                 pipe_fraction(i,j) = 1.0/pipe_cells
-                 pipe_idx(i,j) = 1
-              endif
-            endif
-          enddo
-        enddo
-      endif

--- a/src/grid.F
+++ b/src/grid.F
@@ -13,7 +13,6 @@
       use nc_read_write
       use dimensions
       use roms_read_write
-      use pipe_frc
       use scalars
       use mpi_exchanges
       implicit none
@@ -100,7 +99,7 @@
 
       character(len=99),public  :: ana_grdname
 
-      public :: get_grid
+      public :: init_grid
 
       contains
 
@@ -407,7 +406,7 @@
 
       end subroutine wrt_grid  !]
 !----------------------------------------------------------------------
-      subroutine get_grid  ![
+      subroutine init_grid  ![
       ! read in grid data from NetCDF file or define analytical grid
       implicit none
 
@@ -415,6 +414,8 @@
       integer :: ierr, ncid, varid, lstr, checkdims
       integer,dimension(4) :: start
 
+      ! allocate space for gridded data 
+      call init_arrays_grid
 
 #ifdef ANA_GRID
       call ana_grid
@@ -429,7 +430,7 @@
         ierr=checkdims (ncid, grdname, varid)
         if (ierr. ne. nf90_noerr) goto 99
       else
-        write(*,'(/1x,4A/12x,A)')  '### ERROR: get_grid :: Cannot ',
+        write(*,'(/1x,4A/12x,A)')  '### ERROR: init_grid :: Cannot ',
      &          'open input NetCDF file ''', trim(grdname), '''.',
      &                                            nf90_strerror(ierr)
         goto 99                                          !--> ERROR
@@ -453,7 +454,7 @@
 # ifdef SPHERICAL
         mpi_master_only write(*,'(/1x,A/)') 'Spherical grid detected.'
 # else
-        write(*,'(/1x,2A/24x,A/)')   '### ERROR: get_grid :: ',
+        write(*,'(/1x,2A/24x,A/)')   '### ERROR: init_grid :: ',
      &          'Spherical grid file detected, but CPP-switch',
      &                                 'SPHERICAL is not set.'
         goto 99                                          !--> ERROR
@@ -536,29 +537,29 @@
 #ifdef MPI_SILENT_MODE
         if (mynode==0) then
 #endif
-          write(*,'(6x,4A,1x,A,I4)') 'get_grid :: read grid data ',
+          write(*,'(6x,4A,1x,A,I4)') 'init_grid :: read grid data ',
      &            'from file ''',  trim(grdname), '''.' MYID
 #ifdef MPI_SILENT_MODE
         endif
 #endif
       else
-        write(*,'(1x,4A/12x,A,1x,A,I4)')   '### ERROR: get_grid :: ',
+        write(*,'(1x,4A/12x,A,1x,A,I4)')   '### ERROR: init_grid :: ',
      &                'Cannot close file ''', trim(grdname), '''.',
      &                 nf90_strerror(ierr) MYID
         goto 99
       endif
       return                                     !--> NORMAL RETURN
 
-   1  format(/1x, '### ERROR: get_grid :: Cannot find variable ''', A,
+   1  format(/1x, '### ERROR: init_grid :: Cannot find variable ''', A,
      &                          ''' within netCDF file ''', A, '''.'/)
-   2  format(/1x, '### ERROR: get_grid :: Cannot read variable ''', A,
+   2  format(/1x, '### ERROR: init_grid :: Cannot read variable ''', A,
      &                     ''' from netCDF file ''', A, '''.' /12x,A/)
   99  may_day_flag=2
       return                                             !--> ERROR
 
 #endif /* ifdef ANA_GRID */
 
-      end subroutine get_grid  !]
+      end subroutine init_grid  !]
 
 !----------------------------------------------------------------------
 

--- a/src/init_arrays.F
+++ b/src/init_arrays.F
@@ -59,6 +59,8 @@
       use dimensions
       use flux_frc
       use pipe_frc
+      use river_frc
+      use particles
       use bgc_ecosys_vars
       use bgc_forces
       use bgc
@@ -99,77 +101,45 @@
 # endif
 #endif
 
+! ----- Allocating Arrays -----
+      ! General Variables and File Outputs
       call init_arrays_ocean
-
       call init_avg_arrays
-
-      call init_arrays_coupling
-
-      call init_arrays_grid     ! lots of extra arrays here initialized which might negatively affect first touch principle.
-                                ! before only rmask was first-touched here...
-
-      call init_arrays_mess_buffers  ! DevinD placed here. Assumed used often for higher up first touch
-
-      call init_arrays_eos_vars
-
-#ifdef SOLVE3D
-      do k=0,N
-        do j=jstrR,jendR
-          do i=istrR,iendR
-            We(i,j,k)=init0
-            Wi(i,j,k)=init0
-# ifdef NHMG
-            w(i,j,k,1)=init0
-            w(i,j,k,2)=init0
-# endif
-          enddo
-        enddo
-      enddo
-
-#endif /* SOLVE3D */
-
-! Initialize forcing arrays.
-
+      ! Forcing 
       call init_arrays_surf_flx
-
 #ifdef BULK_FRC
       call init_arrays_bulk_frc
 #endif
-
+#ifndef BULK_FRC
+      call init_arrays_flux_frc
+#endif
+      ! Additional
 # ifdef WEC
       call init_arrays_wec_tile(istr,iend,jstr,jend)
 # endif
-
-#if defined M2NUDGING && !defined M2_FRC_BRY
-      do j=jstrR,jendR
-        do i=istrR,iendR
-          ssh(i,j)=init0
-# ifndef ANA_SSH
-          sshg(i,j,1)=init0
-          sshg(i,j,2)=init0
-# endif
-        enddo
-      enddo
-#endif
-
-! Set variable horizontal viscosities and tracer diffusion
-! coefficients (see "mixing") to their background values.
-
       call init_arrays_mixing
-      call init_arrays_work_mod   ! DevinD added this here to allocate
+      call init_arrays_coupling
+      call init_arrays_mess_buffers
+      call init_arrays_eos_vars
+      call init_arrays_work_mod
       call init_arrays_boundary
-      call init_arrays_buffer     ! DevinD added this here to allocate
-
-#ifndef BULK_FRC
-      call init_arrays_flux_frc   ! DevinD added this here to allocate
-#endif
-
-      if (pipe_source) call init_arrays_pipes
-
+      call init_arrays_buffer
+      ! Biological
 #if defined(BIOLOGY_BEC2) || defined(MARBL)
       call init_arrays_bgc_ecosys_vars
       call init_arrays_bgc_forces
       call init_arrays_bgc_frc
 #endif
+
+! ----- Initialization Routines -----
+      ! Sets up grid through either reading in netcdf files, or, if analytical,
+      ! defining a grid through ana_grid.h
+      call init_grid     ! lots of extra arrays here initialized which might negatively affect first touch principle.
+      ! Places pipes and sets up their forcing
+      if (pipe_source) call init_pipe_frc
+      ! Does the same for rivers, as done in pipes
+      if (river_source) call init_river_frc
+      ! Set up particles if specified
+      if (floats) call init_particles
 
       end

--- a/src/main.F
+++ b/src/main.F
@@ -148,8 +148,6 @@ C$OMP BARRIER
       enddo                              ! are just set to to zero).
 C$OMP BARRIER
 
-      call get_grid                  ! can be analytic or from netcdf
-
 #ifdef DIAGNOSTICS
       call init_diagnostics  
 #endif
@@ -233,7 +231,6 @@ CR      write(*,*) ' -6' MYID
       time=start_time             ! moment "start_time" (global scalar)
       tdays=time*sec2day          ! is set by get_init or analytically
                                   ! copy it into threadprivate "time"
-      call set_forces
       call set_depth(0)
 C$OMP BARRIER
 !----------------------------------------------------------------------
@@ -258,9 +255,6 @@ CR      write(*,*)  ' -3' MYID
 
 CR      write(*,*)  ' -2' MYID
 
-      if (floats) then
-        call init_particles
-      endif
 
 #if defined SPONGE 
       call set_nudgcof(0)

--- a/src/particles.F
+++ b/src/particles.F
@@ -178,20 +178,19 @@
       output_time = 0
 
       ! Print user options (particles.opt) to netcdf attributes 
-      call store_string_att(particle_opt, '')
+      particle_opt = ''
       if (full_seed) then 
-        call store_string_att(particle_opt, 'Seeded with constant density')
-        write(particle_conc_string, '(A, E10.2)') ', Partcile Conc. =', ppm3
+        call store_string_att(particle_opt, 'Constant density')
+        write(particle_conc_string, '(A, E10.2)')', Partcile Conc. =', ppm3
         call store_string_att(particle_opt, particle_conc_string)
-        write(particle_num_string, '(A, I2)') ', Number of Partciles =', np
+        write(particle_num_string, '(A, I3)')', np  =', np
         call store_string_att(particle_opt, particle_num_string)
       else 
-        call store_string_att(particle_opt, 'Seeded Randomly')
+        call store_string_att(particle_opt,'Seeded Randomly')
       endif
-      write(buffer_string, '(A, F5.3)') ', Buffer Space =', extra_space_fac
+      write(buffer_string, '(A, F5.3)')', Buffer Space =', extra_space_fac
       call store_string_att(particle_opt, buffer_string)
        
-
 !     print *,'init particles done'
 
       end subroutine init_particles !]

--- a/src/pipe_frc.F
+++ b/src/pipe_frc.F
@@ -17,6 +17,7 @@
       use roms_read_write
       use nc_read_write
       use scalars
+      use grid
 
       implicit none
 
@@ -33,6 +34,7 @@
       real,public,allocatable,dimension(:,:)    :: pipe_trc      ! Pipe tracer conc.
       real   ,public, dimension(npip)           :: pipe_vol      ! Pipe volume
 
+
      ! Netcdf names
       character(len=9)  :: pipe_flx_name = 'pipe_flux'  !! stored in the grid file
       character(len=11) :: pipe_vol_name = 'pipe_volume'!! stored in a forcing file
@@ -41,10 +43,15 @@
       character(len=5)  ::npipe_dim_name = 'npipe'      !! dimension name for number of pipes in file
       character(len=8)  :: ntrc_dim_name = 'ntracers'   !! dimension name for number of tracers in file
 
+      ! Fix for ana_grid.h error in pipes_ana example
+      real psz, px, py, pipe_cells
+      real sizeX, sizeY
+      real dx, dy
 
       logical :: init_pipe_done = .false.
 
       public set_pipe_frc
+      public init_pipe_frc
       public init_arrays_pipes
 
       contains
@@ -101,10 +108,31 @@
       ! local
       integer :: ierr,ncid,v_id,i,j
 
+      call init_arrays_pipes
 
       if (p_analytical) then
+        ! Also a part of fix for ana_grid.h error
+        SizeX = 30.0e3  !! Domain size in x-direction [m]
+        SizeY = 30.0e3  !! Domain size in y-direction [m]
+        dx = SizeX/gnx
+        dy = SizeY/gny
 
-        ! pipe_flx is defined in ana_pipe_frc.h
+        psz = sizeX*0.02 ! Width of the pipe
+        px  = sizeX*.5  ! x location pipe
+        py  = sizeY*.5  ! y location pipe
+        pipe_cells = nint(psz/dx)**2 !number of cells in this pipe
+        do j=-1,ny+2
+          do i=-1,nx+2
+            pipe_fraction(i,j) = 0.0
+            pipe_idx(i,j) = 0
+            if (xr(i,j)> px-0.5*psz .and. xr(i,j)<px+0.5*psz) then
+              if (yr(i,j)> py-0.5*psz .and. yr(i,j)<py+0.5*psz) then
+                 pipe_fraction(i,j) = 1.0/pipe_cells
+                 pipe_idx(i,j) = 1
+              endif
+            endif
+          enddo
+        enddo
 
       else
 


### PR DESCRIPTION
Currently, arrays are allocated via reference in 'init_arrays', a subroutine apart of 'roms_init' in main.F This commit works to streamline the initialization process by adding to init_arrays the initialization routines for pipe forcing, river forcing, grid definition, and particles. It is a working version and more is planned to be added. In addition to making  the existing init_arrays more readable, the use of ana_grid in the set up of pipes was removed and thus accommodating edits to the example were made. 