### PR TITLE
update CI Makefile to fix bug with repeat calls to Make

### DIFF
--- a/ci/ci_makefiles/src/Makefile
+++ b/ci/ci_makefiles/src/Makefile
@@ -22,6 +22,8 @@ include Makedefs.inc
 # Object and pre-processed source files are source list with extension changes
    RCS = $(SRCS:$(UPF77_ext)=$(PPF77_ext))
   OBJS = $(RCS:$(PPF77_ext)=$(OBJ_ext)) 
+# Sort OBJS to remove duplicates
+  OBJS := $(sort $(OBJS))
 
   SBIN = roms
  LROMS = libroms.a


### PR DESCRIPTION
This short PR updates the CI makefiles (that @garrettstaller is now using to compile with gfortran) such that it is safe to call `make` repeatedly without needing `make compile_clean` between each one.