### PR TITLE
Replace 'shell ls' commands with 'wildcard' in CI Makefile

### DIFF
--- a/ci/ci_makefiles/NHMG/src/Makefile
+++ b/ci/ci_makefiles/NHMG/src/Makefile
@@ -9,7 +9,7 @@ VPATH = ${NETCDFHOME}/include:${ROMS_ROOT}/NHMG/include
 CPATH = ${MPIHOME}/include:${NETCDFHOME}/include:${ROMS_ROOT}/NHMG/include
 
 # Build list of source files (typically most .f90 files)
-SRCS = $(shell ls *$(PPF90_ext))
+SRCS = $(wildcard *$(PPF90_ext))
 
 # Exclude some files from list
 EXCL = mg_diagnostics mg_netcdf_out_false

--- a/ci/ci_makefiles/src/Makefile
+++ b/ci/ci_makefiles/src/Makefile
@@ -5,7 +5,7 @@
 include Makedefs.inc
 
 # Build ROMS source list from unprocessed F77 files (typically .F extension) 
-   SRCS = $(shell ls *$(UPF77_ext))
+   SRCS = $(wildcard *$(UPF77_ext))
 
 # Exclude files that are not part of main build
    EXCL = mpi_test checkkwds cppcheck srcscheck


### PR DESCRIPTION
This two-line change effectively has no impact, but produces more consistent behaviour, by using a Makefile builtin (`wildcard`) rather than a subshell (`shell ls`) in the CI Makefiles.

For some reason `shell ls` wasn't leading to correct substitutions when run inside a subprocess of a `jupyter` on my laptop (in every other context it worked fine). Again, this replacement line is more consistent, and the issue is gone.

Tests are all passing.