### PR TITLE
Separate `river_flux` into two variables

### DIFF
--- a/Examples/code_check/test_roms.py
+++ b/Examples/code_check/test_roms.py
@@ -96,7 +96,7 @@ for test in range(ntests):
 	  dline = 0
 	  while dline < nstps :
 	    line = open(filenames[m],'r').readlines()[iline]
-	    if len(line) > 94 :
+	    if (len(line) > 94) and (len(line.split())==5):
 	      diags[test,m,0] += float(line[ 4:26])     # read Kinetic Energy
 	      diags[test,m,1] += float(line[27:49])     # read barotropic KE
 	      diags[test,m,2] += float(line[50:72])     # read MAX_ADV_CFL        

--- a/src/river_frc.F
+++ b/src/river_frc.F
@@ -22,9 +22,9 @@
 #include "river_frc.opt"
 
       ! Variables used for equation system calculations
-      real   ,public,allocatable,dimension(:,:) :: riv_uflx
-      real   ,public,allocatable,dimension(:,:) :: riv_vflx
-      real   ,public,allocatable,dimension(:,:) :: rflx ! river locations
+      real,public,allocatable,dimension(:,:) :: riv_uflx
+      real,public,allocatable,dimension(:,:) :: riv_vflx
+      real,public,allocatable,dimension(:,:) :: rflx ! river locations
       real   ,public,allocatable,dimension(:,:) :: rfrc ! River fraction
       real   ,public,allocatable,dimension(:,:) :: ridx_real ! River indices (read as real by ncread)
       integer,public,allocatable,dimension(:,:) :: ridx ! River indices (stored as int by ROMS)
@@ -32,13 +32,13 @@
       real,public,dimension(nriv)    :: riv_vol                      ! river volume
       real,public,dimension(nriv,nt) :: riv_trc                      ! river tracer conc.
 
-!integer,public :: iriver  ! river index for looping through rivers
-      integer,public :: iriver                                       ! river index for looping through rivers      
+      integer,public :: iriver                                       ! river index for looping through rivers
       real,   public :: riv_depth
       real,   public :: riv_uvel,riv_vvel
       real,   public :: river_flux
 
       ! Netcdf names
+      character(len=10) :: riv_flx_name = 'river_flux'               ! stored in the grid file
       character(len=12) :: riv_vol_name = 'river_volume'             ! stored in a forcing file
       character(len=12) :: riv_trc_name = 'river_tracer'             ! stored in a forcing file
       character(len=10) :: riv_tim_name = 'river_time'               ! stored in a forcing file
@@ -103,6 +103,7 @@
       allocate( ridx(GLOBAL_2D_ARRAY) )    ; ridx = 0
       allocate( ridx_real(GLOBAL_2D_ARRAY) )    ; ridx_real = 0.
       allocate( rfrc(GLOBAL_2D_ARRAY) )    ; rfrc = 0.      
+      
 
       
       if (analytical) then
@@ -134,9 +135,8 @@
         call ncwrite(ncid,'river_flux', rflx(i0:i1,j0:j1))
         ierr=nf90_close(ncid)
 
-      else ! Not analytical, read from file
-
-!     First, check forcing file for separate index and fraction variables
+      else                      ! Not analytical, read from file
+         ! Start by checking forcing file for separate variables
          ierr=nf90_open(frcfile(nc_rvol%ifile), nf90_nowrite, ncid) ! open river forcing file
          ierr = nf90_inq_varid(ncid, "river_index", varid) ! check river forcing file for index...
          ierr = ierr * nf90_inq_varid(ncid, "river_fraction", varid) ! ... and fraction variables
@@ -151,38 +151,38 @@
                write(*,*) 'ERROR: river_index contains non-integers!'
                stop
             endif
-!     Convert to integer
-         else !     Fallback, check grid for combined index and fraction variable (deprecated):
-            ierr = nf90_close(ncid) ! Close the forcing file
-
-            ierr=nf90_open(grdname, nf90_nowrite, ncid) ! open grid file
-            ierr = nf90_inq_varid(ncid, "river_flux", varid) ! check grid file for variable
+         else ! if not in the forcing file, look for a single variable in the grid file
+            ierr=nf90_close(ncid)
+            ierr=nf90_open(grdname, nf90_nowrite, ncid)
+            ierr = nf90_inq_varid(ncid, riv_flx_name, varid) ! check grid file for variable
          
-            if (ierr /= nf90_noerr) then ! True if required vars in neither file
+            if (ierr /= nf90_noerr) then ! if not in grid file
+               ierr = nf90_close(ncid) ! close grid file
                call handle_ierr(ierr, 'init_riv:: '//
-     &              'unable to find a single variable (`river_flux`)'//
-     &              ' or separate variables '//
-     &              '(`river_index`,`river_fraction`) in either the'//
-     &              ' grid (' // trim(grdname) //') '//
-     &              ' or river forcing (' // trim(frcfile(nc_rvol%ifile)) //
-     &              ') files. ROMS is unable to determine '//
-     &              'how to distribute river inputs')
-            else                !It's in one of the two files (current ncid)
+     &              'unable to find river index and fraction'//
+     &              ' either as separate variables '//
+     &              ' (river_index, river_fraction) in river '//
+     &              ' forcing file ('// trim(frcfile(nc_rvol%ifile)) //
+     &              ') or as a combined variable ('// trim(riv_flx_name) //
+     &              ', deprecated) in grid (' // trim(grdname)//
+     &              ') file.')
+            else
                if (mynode == 0) then
-                  write(*,'(/7x,A/)') 'DEPRECATION WARNING, init_riv: '//
+                  write(*,'(/7x,A/)') 'DEPRECATION WARNING, init_riv:'//
      &                 'ROMS has located a single variable '//
      &                 '(river_flux) containing both river index '//
-     &                 ' and fraction. This behavior is deprecated '//
+     &                 ' and fraction in the grid file ('// trim(grdname)//
+     &                 '). This behavior is deprecated '//
      &                 'as of March 2025 and will be removed in a '//
      &                 'future version. Please provide separate ' //
-     &                 'variables: river_index and river_fraction.'
+     &                 'variables: river_index and river_fraction '//
+     &                 ' in the river forcing file ('// 
+     &                 trim(frcfile(nc_rvol%ifile))//').'
                end if
+                  
 
-!     Read from whichever of the two files contains the variable
-               call ncread(ncid, "river_flux", rflx(i0:i1,j0:j1))
+               call ncread(ncid, riv_flx_name, rflx(i0:i1,j0:j1))
                ierr = nf90_close(ncid)
-!     Split the variable up here for later use
-!     ridx(i0:i1,j0:j1) = floor(rflx(i0:i1,j0:j1)-1e-5)
                where (rflx(i0:i1, j0:j1) > 0)
                   ridx(i0:i1, j0:j1) = floor(rflx(i0:i1, j0:j1) - 1e-5)
                   rfrc(i0:i1,j0:j1) = rflx(i0:i1,j0:j1) - ridx(i0:i1,j0:j1)                  
@@ -190,9 +190,9 @@
                   ridx(i0:i1, j0:j1) = 0
                   rfrc(i0:i1, j0:j1) = 0
                end where
-            end if
-         end if                 ! separate river_index, river_fraction vars (T) single river_flux var (F)
-      endif                     ! analytical
+            end if ! found in grid file               
+         end if                 ! Separate variables found in forcing file
+      endif !analytical
 
       call calc_river_flux                                           ! compute uflx,vflx from rflx
 
@@ -205,7 +205,7 @@
 ! ----------------------------------------------------------------------
       subroutine calc_river_flux  ![
       ! calculate the river flux contributions to each cell.
-      ! river_flux = index + fraction of river's flux through grid point.
+      ! river_flux = iriver + fraction of river's flux through grid point.
       ! e.g. River 3 is over 2 grid points (half flux through each point),
       ! hence river_flux = 3 + 0.5 = 3.5
       implicit none
@@ -213,29 +213,31 @@
       ! local
       integer :: i,j,faces
 
-! compute uflx,vflx from rflx
+      ! compute uflx,vflx from rflx
       do j = 0,ny+1   ! Loop over -1 and +1 because rflx cell only flows into
         do i = 0,nx+1 ! neighbour, hence cell next to boundary could flow into cell.
           if (rfrc(i,j) > 0) then ! distribute mass flux to all available unmasked cells
             ! subtract 1e-5 in case only 1 grid point for river, so that floor still
             ! produces correct iriver number.
 !            write(*,*) 'mynode=',mynode,'i,j',i,j,rflx(i,j),'rflx(i,j)'
-
+             !iriver = floor(rflx(i,j)-1e-5)
+             !iriver = ridx(i,j)
 #ifdef MASKING
             faces =  rmask(i-1,j)+rmask(i+1,j)+rmask(i,j-1)+rmask(i,j+1) !! amount of unmasked cells around
             if ( faces == 0 .or. rmask(i,j)>0  ) then
               error stop 'river grid position error'
             endif
-            ! 10*ridx needed because uflx/vflx can be positive or negative around
-!           the ridx number, and hence nearest integer is safest done with 10*.
-            if (rmask(i-1,j)>0 ) riv_uflx(i  ,j) =-rfrc(i,j)/faces + 10*ridx(i,j)
-            if (rmask(i+1,j)>0 ) riv_uflx(i+1,j) = rfrc(i,j)/faces + 10*ridx(i,j)
-            if (rmask(i,j-1)>0 ) riv_vflx(i,j  ) =-rfrc(i,j)/faces + 10*ridx(i,j)
-            if (rmask(i,j+1)>0 ) riv_vflx(i,j+1) = rfrc(i,j)/faces + 10*ridx(i,j)
+            ! 10*iriver needed because uflx/vflx can be positive or negative around
+            ! the iriver number, and hence nearest integer is safest done with 10*.
+            if (rmask(i-1,j)>0 ) riv_uflx(i  ,j) =-(rfrc(i,j))/faces + 10*ridx(i,j)
+            if (rmask(i+1,j)>0 ) riv_uflx(i+1,j) = (rfrc(i,j))/faces + 10*ridx(i,j)
+            if (rmask(i,j-1)>0 ) riv_vflx(i,j  ) =-(rfrc(i,j))/faces + 10*ridx(i,j)
+            if (rmask(i,j+1)>0 ) riv_vflx(i,j+1) = (rfrc(i,j))/faces + 10*ridx(i,j)
 #endif
           endif
         enddo
       enddo
+
       end subroutine calc_river_flux  !]
 ! ----------------------------------------------------------------------
       subroutine set_ana_river_frc  ![

--- a/src/river_frc.F
+++ b/src/river_frc.F
@@ -137,13 +137,11 @@
       else ! Not analytical, read from file
 
 !     First, check forcing file for separate index and fraction variables
-         if(mynode==0) print *, 'we here 1'
          ierr=nf90_open(frcfile(nc_rvol%ifile), nf90_nowrite, ncid) ! open river forcing file
          ierr = nf90_inq_varid(ncid, "river_index", varid) ! check river forcing file for index...
          ierr = ierr * nf90_inq_varid(ncid, "river_fraction", varid) ! ... and fraction variables
          
          if (ierr == nf90_noerr) then ! Found the variables in the forcing file
-            if(mynode==0) print *, 'we here 2'            
             call ncread(ncid, "river_index", ridx_real(i0:i1,j0:j1))
             call ncread(ncid, "river_fraction", rfrc(i0:i1,j0:j1))
             ierr = nf90_close(ncid)            
@@ -154,7 +152,6 @@
                stop
             endif
 !     Convert to integer
-            if(mynode==0) print *, 'we here 3'            
          else !     Fallback, check grid for combined index and fraction variable (deprecated):
             ierr = nf90_close(ncid) ! Close the forcing file
 
@@ -195,7 +192,6 @@
                end where
             end if
          end if                 ! separate river_index, river_fraction vars (T) single river_flux var (F)
-         if(mynode==0) print *, 'we here 4'         
       endif                     ! analytical
 
       call calc_river_flux                                           ! compute uflx,vflx from rflx
@@ -218,7 +214,6 @@
       integer :: i,j,faces
 
 ! compute uflx,vflx from rflx
-      if(mynode==0) print *, 'we here 5'         
       do j = 0,ny+1   ! Loop over -1 and +1 because rflx cell only flows into
         do i = 0,nx+1 ! neighbour, hence cell next to boundary could flow into cell.
           if (rfrc(i,j) > 0) then ! distribute mass flux to all available unmasked cells
@@ -241,7 +236,6 @@
           endif
         enddo
       enddo
-      if(mynode==0) print *, 'we here 6' 
       end subroutine calc_river_flux  !]
 ! ----------------------------------------------------------------------
       subroutine set_ana_river_frc  ![

--- a/src/river_frc.F
+++ b/src/river_frc.F
@@ -117,7 +117,8 @@
               ! find 'coastline' masked cells
 # ifdef MASKING
               if (rmask(i,j)==0 .and. rmask(i,j+1)==1) then
-                rflx(i,j) = 1.0+1.0/riv_cells
+                 ridx(i,j) = 1
+                 rfrc(i,j) = 1/riv_cells
               endif
 # endif
             endif

--- a/src/river_frc.F
+++ b/src/river_frc.F
@@ -22,19 +22,23 @@
 #include "river_frc.opt"
 
       ! Variables used for equation system calculations
-      real,public,allocatable,dimension(:,:) :: riv_uflx
-      real,public,allocatable,dimension(:,:) :: riv_vflx
-      real,public,allocatable,dimension(:,:) :: rflx                 ! river locations
+      real   ,public,allocatable,dimension(:,:) :: riv_uflx
+      real   ,public,allocatable,dimension(:,:) :: riv_vflx
+      real   ,public,allocatable,dimension(:,:) :: rflx ! river locations
+      real   ,public,allocatable,dimension(:,:) :: rfrc ! River fraction
+      real   ,public,allocatable,dimension(:,:) :: ridx_real ! River indices (read as real by ncread)
+      integer,public,allocatable,dimension(:,:) :: ridx ! River indices (stored as int by ROMS)
+      
       real,public,dimension(nriv)    :: riv_vol                      ! river volume
       real,public,dimension(nriv,nt) :: riv_trc                      ! river tracer conc.
 
-      integer,public :: iriver                                       ! river index for looping through rivers
+!integer,public :: iriver  ! river index for looping through rivers
+      integer,public :: iriver                                       ! river index for looping through rivers      
       real,   public :: riv_depth
       real,   public :: riv_uvel,riv_vvel
       real,   public :: river_flux
 
       ! Netcdf names
-      character(len=10) :: riv_flx_name = 'river_flux'               ! stored in the grid file
       character(len=12) :: riv_vol_name = 'river_volume'             ! stored in a forcing file
       character(len=12) :: riv_trc_name = 'river_tracer'             ! stored in a forcing file
       character(len=10) :: riv_tim_name = 'river_time'               ! stored in a forcing file
@@ -96,6 +100,9 @@
       allocate( riv_uflx(GLOBAL_2D_ARRAY) ); riv_uflx = 0.
       allocate( riv_vflx(GLOBAL_2D_ARRAY) ); riv_vflx = 0.
       allocate( rflx(GLOBAL_2D_ARRAY) )    ; rflx = 0.
+      allocate( ridx(GLOBAL_2D_ARRAY) )    ; ridx = 0
+      allocate( ridx_real(GLOBAL_2D_ARRAY) )    ; ridx_real = 0.
+      allocate( rfrc(GLOBAL_2D_ARRAY) )    ; rfrc = 0.      
 
       
       if (analytical) then
@@ -127,28 +134,69 @@
         call ncwrite(ncid,'river_flux', rflx(i0:i1,j0:j1))
         ierr=nf90_close(ncid)
 
-      else ! Read 'river_flux' from grid file (River mouth locations)
-         ierr=nf90_open(grdname, nf90_nowrite, ncid)
-         ierr = nf90_inq_varid(ncid, riv_flx_name, varid) ! check grid file for variable
+      else ! Not analytical, read from file
+
+!     First, check forcing file for separate index and fraction variables
+         if(mynode==0) print *, 'we here 1'
+         ierr=nf90_open(frcfile(nc_rvol%ifile), nf90_nowrite, ncid) ! open river forcing file
+         ierr = nf90_inq_varid(ncid, "river_index", varid) ! check river forcing file for index...
+         ierr = ierr * nf90_inq_varid(ncid, "river_fraction", varid) ! ... and fraction variables
          
-         if (ierr /= nf90_noerr) then ! if not in grid file
-            ierr = nf90_close(ncid)    ! close grid file
-            ierr=nf90_open(frcfile(nc_rvol%ifile), nf90_nowrite, ncid) ! open river forcing file
-            ierr = nf90_inq_varid(ncid, riv_flx_name, varid) ! check river forcing file for variable
-            if (ierr /= nf90_noerr) then
+         if (ierr == nf90_noerr) then ! Found the variables in the forcing file
+            if(mynode==0) print *, 'we here 2'            
+            call ncread(ncid, "river_index", ridx_real(i0:i1,j0:j1))
+            call ncread(ncid, "river_fraction", rfrc(i0:i1,j0:j1))
+            ierr = nf90_close(ncid)            
+!     Check for non-integer values
+            ridx(i0:i1, j0:j1) = int(ridx_real(i0:i1, j0:j1))
+            if (any(abs(ridx_real(i0:i1,j0:j1) - ridx(i0:i1,j0:j1)) > 1.0e-6)) then
+               write(*,*) 'ERROR: river_index contains non-integers!'
+               stop
+            endif
+!     Convert to integer
+            if(mynode==0) print *, 'we here 3'            
+         else !     Fallback, check grid for combined index and fraction variable (deprecated):
+            ierr = nf90_close(ncid) ! Close the forcing file
+
+            ierr=nf90_open(grdname, nf90_nowrite, ncid) ! open grid file
+            ierr = nf90_inq_varid(ncid, "river_flux", varid) ! check grid file for variable
+         
+            if (ierr /= nf90_noerr) then ! True if required vars in neither file
                call handle_ierr(ierr, 'init_riv:: '//
-     &          'river location variable (' // trim(riv_flx_name) //
-     &          ') not found in grid (' // trim(grdname) //') '//
-     &          ' or river forcing (' // trim(frcfile(nc_rvol%ifile)) //
-     &          ') files')
+     &              'unable to find a single variable (`river_flux`)'//
+     &              ' or separate variables '//
+     &              '(`river_index`,`river_fraction`) in either the'//
+     &              ' grid (' // trim(grdname) //') '//
+     &              ' or river forcing (' // trim(frcfile(nc_rvol%ifile)) //
+     &              ') files. ROMS is unable to determine '//
+     &              'how to distribute river inputs')
+            else                !It's in one of the two files (current ncid)
+               if (mynode == 0) then
+                  write(*,'(/7x,A/)') 'DEPRECATION WARNING, init_riv: '//
+     &                 'ROMS has located a single variable '//
+     &                 '(river_flux) containing both river index '//
+     &                 ' and fraction. This behavior is deprecated '//
+     &                 'as of March 2025 and will be removed in a '//
+     &                 'future version. Please provide separate ' //
+     &                 'variables: river_index and river_fraction.'
+               end if
+
+!     Read from whichever of the two files contains the variable
+               call ncread(ncid, "river_flux", rflx(i0:i1,j0:j1))
+               ierr = nf90_close(ncid)
+!     Split the variable up here for later use
+!     ridx(i0:i1,j0:j1) = floor(rflx(i0:i1,j0:j1)-1e-5)
+               where (rflx(i0:i1, j0:j1) > 0)
+                  ridx(i0:i1, j0:j1) = floor(rflx(i0:i1, j0:j1) - 1e-5)
+                  rfrc(i0:i1,j0:j1) = rflx(i0:i1,j0:j1) - ridx(i0:i1,j0:j1)                  
+               elsewhere
+                  ridx(i0:i1, j0:j1) = 0
+                  rfrc(i0:i1, j0:j1) = 0
+               end where
             end if
-         end if
-            
-         ! Read from whichever of the two files contains the variable
-         call ncread(ncid, riv_flx_name, rflx(i0:i1,j0:j1))
-         ierr = nf90_close(ncid)
-        
-      endif
+         end if                 ! separate river_index, river_fraction vars (T) single river_flux var (F)
+         if(mynode==0) print *, 'we here 4'         
+      endif                     ! analytical
 
       call calc_river_flux                                           ! compute uflx,vflx from rflx
 
@@ -161,7 +209,7 @@
 ! ----------------------------------------------------------------------
       subroutine calc_river_flux  ![
       ! calculate the river flux contributions to each cell.
-      ! river_flux = iriver + fraction of river's flux through grid point.
+      ! river_flux = index + fraction of river's flux through grid point.
       ! e.g. River 3 is over 2 grid points (half flux through each point),
       ! hence river_flux = 3 + 0.5 = 3.5
       implicit none
@@ -169,30 +217,31 @@
       ! local
       integer :: i,j,faces
 
-      ! compute uflx,vflx from rflx
+! compute uflx,vflx from rflx
+      if(mynode==0) print *, 'we here 5'         
       do j = 0,ny+1   ! Loop over -1 and +1 because rflx cell only flows into
         do i = 0,nx+1 ! neighbour, hence cell next to boundary could flow into cell.
-          if (rflx(i,j) > 0) then ! distribute mass flux to all available unmasked cells
+          if (rfrc(i,j) > 0) then ! distribute mass flux to all available unmasked cells
             ! subtract 1e-5 in case only 1 grid point for river, so that floor still
             ! produces correct iriver number.
 !            write(*,*) 'mynode=',mynode,'i,j',i,j,rflx(i,j),'rflx(i,j)'
-            iriver = floor(rflx(i,j)-1e-5)
+
 #ifdef MASKING
             faces =  rmask(i-1,j)+rmask(i+1,j)+rmask(i,j-1)+rmask(i,j+1) !! amount of unmasked cells around
             if ( faces == 0 .or. rmask(i,j)>0  ) then
               error stop 'river grid position error'
             endif
-            ! 10*iriver needed because uflx/vflx can be positive or negative around
-            ! the iriver number, and hence nearest integer is safest done with 10*.
-            if (rmask(i-1,j)>0 ) riv_uflx(i  ,j) =-(rflx(i,j)-iriver)/faces + 10*iriver
-            if (rmask(i+1,j)>0 ) riv_uflx(i+1,j) = (rflx(i,j)-iriver)/faces + 10*iriver
-            if (rmask(i,j-1)>0 ) riv_vflx(i,j  ) =-(rflx(i,j)-iriver)/faces + 10*iriver
-            if (rmask(i,j+1)>0 ) riv_vflx(i,j+1) = (rflx(i,j)-iriver)/faces + 10*iriver
+            ! 10*ridx needed because uflx/vflx can be positive or negative around
+!           the ridx number, and hence nearest integer is safest done with 10*.
+            if (rmask(i-1,j)>0 ) riv_uflx(i  ,j) =-rfrc(i,j)/faces + 10*ridx(i,j)
+            if (rmask(i+1,j)>0 ) riv_uflx(i+1,j) = rfrc(i,j)/faces + 10*ridx(i,j)
+            if (rmask(i,j-1)>0 ) riv_vflx(i,j  ) =-rfrc(i,j)/faces + 10*ridx(i,j)
+            if (rmask(i,j+1)>0 ) riv_vflx(i,j+1) = rfrc(i,j)/faces + 10*ridx(i,j)
 #endif
           endif
         enddo
       enddo
-
+      if(mynode==0) print *, 'we here 6' 
       end subroutine calc_river_flux  !]
 ! ----------------------------------------------------------------------
       subroutine set_ana_river_frc  ![


### PR DESCRIPTION
This PR refactors `river_frc.F` to first search the river forcing file for the variable pair `river_index` and `river_fraction`, before falling back on searching for a single combined variable `river_flux` in the grid file. 

In the latter case (`river_flux` in grid), a deprecation warning is issued. The single variable is split into the two separate arrays in the `init_river` subroutine and the code proceeds the same way as in the former case.

I have fully tested the code with an 8-river domain including BGC (as well as the single-river test case), and the output is bit-for-bit.

The current implementation is pretty minimal , and doesn't leave the `river_forcing` module, but there are several other modules that combine and divide the fraction and index in ways that are now unnecessary, that we may wish to update as well.