### PR TITLE
Bugfixes for IFX

### DIFF
--- a/src/ana_frc_river.h
+++ b/src/ana_frc_river.h
@@ -7,6 +7,8 @@
       ! Set river volume and tracer values for each time step
       riv_vol(1)   = 5e2  ! Volume flux in m3/s
       riv_trc(1,1) = 24.0 ! Temperature in  Degrees C
+#ifdef SALINITY  
       riv_trc(1,2) =  1.0  ! Salinity in PSU
+#endif  
       
       

--- a/src/nc_read_write.F
+++ b/src/nc_read_write.F
@@ -126,28 +126,20 @@
       integer              :: varid,ierr
       integer,dimension(1) :: dims
       integer,dimension(2) :: count
-      real, allocatable    :: tmp_array(:)
       
       dims = shape(dat)
       
-!     Allocate a contiguous temporary array on the heap
-      allocate(tmp_array(dims(1)))
-
-!     Copy data to the temporary array to ensure contiguous storage
-      tmp_array = dat
-
       ierr = nf90_inq_varid(ncid,vname,varid)
       if (ierr/=0) call handle_ierr(ierr,'ncwrite inq_varid var=',vname)
 
       if (present(start)) then
         count = (/dims, 1/)
-        ierr = nf90_put_var(ncid,varid,tmp_array,start,count)
+        ierr = nf90_put_var(ncid,varid,dat,start,count)
       else
-        ierr = nf90_put_var(ncid,varid,tmp_array)
+        ierr = nf90_put_var(ncid,varid,dat)
       endif
       if (ierr/=0) call handle_ierr(ierr,'ncwrite write var=',vname)
 
-      deallocate(tmp_array)
       end subroutine ncwrite_1D  !]
 !----------------------------------------------------------------------
       subroutine ncwrite_2D(ncid,vname,dat,start)  ![
@@ -164,28 +156,20 @@
       integer              :: varid,ierr
       integer,dimension(2) :: dims
       integer,dimension(3) :: count
-      real, allocatable    :: tmp_array(:,:)
       
       dims = shape(dat)
-      
-!     Allocate a contiguous temporary array on the heap
-      allocate(tmp_array(dims(1), dims(2)))
-
-!     Copy data to the temporary array to ensure contiguous storage
-      tmp_array = dat
       
       ierr = nf90_inq_varid(ncid,vname,varid)
       if (ierr/=0) call handle_ierr(ierr,'ncwrite inq_varid var=',vname)
 
       if (present(start)) then
         count = (/dims, 1/)
-        ierr = nf90_put_var(ncid,varid,tmp_array,start,count)
+        ierr = nf90_put_var(ncid,varid,dat,start,count)
       else
-        ierr = nf90_put_var(ncid,varid,tmp_array)
+        ierr = nf90_put_var(ncid,varid,dat)
       endif
       if (ierr/=0) call handle_ierr(ierr,'ncwrite write var=',vname)
 
-      deallocate(tmp_array)
       end subroutine ncwrite_2D  !]
 !----------------------------------------------------------------------
       subroutine ncwrite_3D(ncid,vname,dat,start)  ![

--- a/src/nc_read_write.F
+++ b/src/nc_read_write.F
@@ -147,6 +147,7 @@
       endif
       if (ierr/=0) call handle_ierr(ierr,'ncwrite write var=',vname)
 
+      deallocate(tmp_array)
       end subroutine ncwrite_1D  !]
 !----------------------------------------------------------------------
       subroutine ncwrite_2D(ncid,vname,dat,start)  ![
@@ -184,6 +185,7 @@
       endif
       if (ierr/=0) call handle_ierr(ierr,'ncwrite write var=',vname)
 
+      deallocate(tmp_array)
       end subroutine ncwrite_2D  !]
 !----------------------------------------------------------------------
       subroutine ncwrite_3D(ncid,vname,dat,start)  ![
@@ -222,6 +224,7 @@
       endif
       if (ierr/=0) call handle_ierr(ierr,'ncwrite write var=',vname)
 
+      deallocate(tmp_array)
       end subroutine ncwrite_3D  !]
 !----------------------------------------------------------------------
       integer function nccreate(ncid,varname,dimname,dimsize,vartype)  ![

--- a/src/nc_read_write.F
+++ b/src/nc_read_write.F
@@ -126,16 +126,24 @@
       integer              :: varid,ierr
       integer,dimension(1) :: dims
       integer,dimension(2) :: count
-
+      real, allocatable    :: tmp_array(:)
+      
       dims = shape(dat)
+      
+!     Allocate a contiguous temporary array on the heap
+      allocate(tmp_array(dims(1)))
+
+!     Copy data to the temporary array to ensure contiguous storage
+      tmp_array = dat
+
       ierr = nf90_inq_varid(ncid,vname,varid)
       if (ierr/=0) call handle_ierr(ierr,'ncwrite inq_varid var=',vname)
 
       if (present(start)) then
         count = (/dims, 1/)
-        ierr = nf90_put_var(ncid,varid,dat,start,count)
+        ierr = nf90_put_var(ncid,varid,tmp_array,start,count)
       else
-        ierr = nf90_put_var(ncid,varid,dat)
+        ierr = nf90_put_var(ncid,varid,tmp_array)
       endif
       if (ierr/=0) call handle_ierr(ierr,'ncwrite write var=',vname)
 
@@ -155,16 +163,24 @@
       integer              :: varid,ierr
       integer,dimension(2) :: dims
       integer,dimension(3) :: count
-
+      real, allocatable    :: tmp_array(:,:)
+      
       dims = shape(dat)
+      
+!     Allocate a contiguous temporary array on the heap
+      allocate(tmp_array(dims(1), dims(2)))
+
+!     Copy data to the temporary array to ensure contiguous storage
+      tmp_array = dat
+      
       ierr = nf90_inq_varid(ncid,vname,varid)
       if (ierr/=0) call handle_ierr(ierr,'ncwrite inq_varid var=',vname)
 
       if (present(start)) then
         count = (/dims, 1/)
-        ierr = nf90_put_var(ncid,varid,dat,start,count)
+        ierr = nf90_put_var(ncid,varid,tmp_array,start,count)
       else
-        ierr = nf90_put_var(ncid,varid,dat)
+        ierr = nf90_put_var(ncid,varid,tmp_array)
       endif
       if (ierr/=0) call handle_ierr(ierr,'ncwrite write var=',vname)
 
@@ -184,16 +200,25 @@
       integer              :: varid,ierr
       integer,dimension(3) :: dims
       integer,dimension(4) :: count
+      real, allocatable    :: tmp_array(:,:,:)
 
+      
       dims = shape(dat)
+      
+!     Allocate a contiguous temporary array on the heap
+      allocate(tmp_array(dims(1), dims(2), dims(3)))
+
+!     Copy data to the temporary array to ensure contiguous storage
+      tmp_array = dat
+
       ierr = nf90_inq_varid(ncid,vname,varid)
       if (ierr/=0) call handle_ierr(ierr,'ncwrite inq_varid var=',vname)
 
       if (present(start)) then
         count = (/dims, 1/)
-        ierr = nf90_put_var(ncid,varid,dat,start,count)
+        ierr = nf90_put_var(ncid,varid,tmp_array,start,count)
       else
-        ierr = nf90_put_var(ncid,varid,dat)
+        ierr = nf90_put_var(ncid,varid,tmp_array)
       endif
       if (ierr/=0) call handle_ierr(ierr,'ncwrite write var=',vname)
 

--- a/src/set_scoord.F
+++ b/src/set_scoord.F
@@ -26,23 +26,25 @@
       enddo
 
 
-      mpi_master_only write(*,'(/1x,A/,/2x,A,7x,A/)')
-     &        'Vertical S-coordinate system (z at W-points):',
-     &             'level   S-coord    Cs-curve    Z at hmin',
-     &                        'at hc    half way     at hmax'
+      mpi_master_only write(*,'(/1x,A/)')
+     &        'Vertical S-coordinate system (z at W-points):'
+
+      mpi_master_only write(*,
+     &     '(A7,2x,A11,2x,A14,2x,A16,2x,A14,2x,A14,2x,A14)')
+     &     'level', 'S-coord', 'Cs-curve', 'Z at hmin',
+     &     'at hc', 'half way', 'at hmax'
+
+      
       do k=N,0,-1
         sc=ds*dble(k-N)
         z1=hmin*(hc*sc + hmin*Cs_w(k))/(hc+hmin)
         zhc=0.5*hc*(sc + Cs_w(k))
         z2=0.5*hmax*(hc*sc + 0.5*hmax*Cs_w(k))/(hc+0.5*hmax)
         z3=hmax*(hc*sc + hmax*Cs_w(k))/(hc+hmax)
-        if (hc < 1.E+4) then
-          mpi_master_only write(*,'(I7,F11.6,F12.7,4F12.3)')
-     &                              k, ds*(k-N),Cs_w(k), z1,zhc,z2,z3
-        else
-         mpi_master_only write(*,'(I7,F11.6,F12.7,F12.3,12x,2F12.3)')
-     &                              k, ds*(k-N),Cs_w(k), z1,    z2,z3
-        endif
+        
+        mpi_master_only write(*,
+     &'(I7,2X,ES11.4,2X,ES14.7,2X,ES16.7,2X,ES14.7,2X,ES14.7,2X,ES14.7)')
+     &       k, ds*(k-N), Cs_w(k), z1, zhc, z2, z3
       enddo
       end
 


### PR DESCRIPTION
This PR addresses a few code problems caught by the new compiler. It does not change the compiler or makefiles (this will be a separate PR), just addresses a few internal issues.

- Add missing CPP check for salinity in `ana_frc_river.h`
- Allocate explicit temporary contiguous arrays in `ncwrite_XD` to prevent segfaults caused by implict stack-based temporary arrays created by compiler (`nc_read_write.F`)
- change format of vertical coordinate system (`set_scoord.F`) in output stream to account for very large `hmin`,`hmax` values