### PR TITLE
Generalise MPI wrapper in CI Makedefs.inc 

### DIFF
--- a/ci/ci_makefiles/src/Makedefs.inc
+++ b/ci/ci_makefiles/src/Makedefs.inc
@@ -35,18 +35,16 @@ ifeq ($(OS),Darwin)
     PPF77_ext = .fpp
 endif
 
+## Use mpifort as the wrapper for any compiler:
+LDR = mpifort
+CFT = mpifort
+
 ## Set linker and compiler based on compiler/MPI wrapper
 ifeq ($(COMPILER),gnu)
-	LDR =  mpifort
-        CFT =  mpifort
 	expected_fc=GNU Fortran # For checking correct compiler is wrapped
 else ifeq ($(COMPILER),intel)
-        LDR = mpiifx
-        CFT = mpiifx
 	expected_fc=ifx
 else ifeq ($(COMPILER),ifort)
-        LDR = mpifort
-        CFT = mpifort
 	expected_fc=ifort
 endif
 


### PR DESCRIPTION
This tweak modifies the CI Makedefs.inc to decouple the MPI wrapper around the compiler from the compiler itself. Previously, compiling with `COMPILER=ifort`  set `mpifort` as the wrapper, while `COMPILER=ifx` set `mpiifx`. However, the `mpiifx` wrapper is primarily associated with Intel MPI , while `mpifort` is more universal and is equivalent to `mpiifx` with Intel MPI anyway.
This PR simply sets the wrapper to `mpifort` regardless of compiler.