### PR TITLE
Critical fix to KPP

### DIFF
--- a/src/lmd_kpp.F
+++ b/src/lmd_kpp.F
@@ -229,7 +229,7 @@
 
 c--         Vtsq=Vtc*ws*sqrt(max(0., 0.5*(bvf(i,j,k)+bvf(i,j,k-1)) ))
 
-            Vtsq=Vtc*ws*sqrt(max(0., bvf(i,j,k-1) ))  !<-- fix by Gokhan
+            Vtsq=1.8*Vtc*ws*sqrt(max(1.e-5, bvf(i,j,k-1) ))  !<-- fix by Jeroen
 
             Cr(i,k)=FC(i,k)+Vtsq
 
@@ -417,7 +417,7 @@ c--         Vtsq=Vtc*ws*sqrt(max(0., 0.5*(bvf(i,j,k)+bvf(i,j,k-1)) ))
 
 #  ifdef LMD_NONLOCAL
               if (Bfsfc < 0.) then
-                ghat(i,j,k)=Cg * ssgm*(1.-ssgm)**2
+                ghat(i,j,k)=-Cg * ssgm*(1.-ssgm)**2
               else
                 ghat(i,j,k)=0.
               endif


### PR DESCRIPTION
It was recently discovered that the nonlocal transport in kpp was incorrectly implemented. Instead of fluxing heat upward during surface cooling, it was fluxing heat downward. This serious bug was in the code for over 2 decades.....

This commit fixes that, and tunes the entraiment flux during unstable (convective) conditions to recover a 20% entrainment flux for free convection and avoid spurious detections of the mixed layer depth in the middle of the mixing layer.